### PR TITLE
WELD-2224 Excerpt generated logger classes from checkstyle plugin. Update paren…

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-parent</artifactId>
-        <version>31</version>
+        <version>35</version>
     </parent>
 
     <groupId>org.jboss.weld</groupId>

--- a/build-config/src/main/resources/weld-checkstyle/checkstyle-suppressions.xml
+++ b/build-config/src/main/resources/weld-checkstyle/checkstyle-suppressions.xml
@@ -9,4 +9,7 @@
   -->
   <suppress checks="MagicNumberCheck" files="org[\\/]jboss[\\/]weld[\\/]logging[\\/].*Logger.java" />
   <suppress checks="MagicNumberCheck" files="org[\\/]jboss[\\/]weld[\\/].*[\\/]logging[\\/].*Logger.java" />
+  <!--Do not check generated logger files-->
+  <suppress checks="[a-zA-Z0-9]" files="org[\\/]jboss[\\/]weld[\\/].*logging[\\/].*\_\$logger.java" />
+  <suppress checks="[a-zA-Z0-9]" files="org[\\/]jboss[\\/]weld[\\/]probe[\\/].*\_\$logger.java" />
 </suppressions>


### PR DESCRIPTION
…t version.

Using Maven compiler plugin newer than 3.1 means there is a fix adding generated code into `sourceRoots` which means Maven checkstyle will pick it up.