### PR TITLE
Add patch file for WilfFly 11 with Weld 3.

### DIFF
--- a/wildfly/patch-config-wildfly-10-weld-2.2.xml
+++ b/wildfly/patch-config-wildfly-10-weld-2.2.xml
@@ -15,5 +15,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-10-weld-2.3.xml
+++ b/wildfly/patch-config-wildfly-10-weld-2.3.xml
@@ -16,5 +16,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-10-weld-2.4.xml
+++ b/wildfly/patch-config-wildfly-10-weld-2.4.xml
@@ -16,5 +16,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-11-weld-3.0.xml
+++ b/wildfly/patch-config-wildfly-11-weld-3.0.xml
@@ -1,20 +1,28 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <patch-config xmlns="urn:jboss:patch-config:1.0">
-    <name>wildfly-10-weld-3.0</name>
+    <name>wildfly-11-weld-3.0</name>
     <description>This patch upgrades Weld to 3.0 within WildFly installation</description>
     <one-off />
-    <element patch-id="layer-base-wildfly-10-weld-3.0">
+    <element patch-id="layer-base-wildfly-11-weld-3.0">
         <one-off name="base" />
-        <description>This patch upgrades Weld o 3.0 within WildFly installation</description>
+        <description>This patch upgrades Weld to 3.0 within WildFly installation</description>
         <specified-content>
             <modules>
                 <updated name="org.jboss.as.jsf-injection" />
                 <updated name="org.jboss.as.weld" />
+                <updated name="org.jboss.as.weld.beanvalidation" />
+                <updated name="org.jboss.as.weld.common" />
+                <updated name="org.jboss.as.weld.ejb" />
+                <updated name="org.jboss.as.weld.jpa" />
+                <updated name="org.jboss.as.weld.spi" />
+                <updated name="org.jboss.as.weld.transactions" />
+                <updated name="org.jboss.as.weld.webservices" />
                 <updated name="org.jboss.weld.api" />
                 <updated name="org.jboss.weld.core" />
                 <updated name="org.jboss.weld.probe" />
                 <updated name="org.jboss.weld.spi" />
                 <updated name="javax.enterprise.api" />
+                <updated name="javax.annotation.api" />
             </modules>
         </specified-content>
     </element>

--- a/wildfly/patch-config-wildfly-8.2-weld-2.2.xml
+++ b/wildfly/patch-config-wildfly-8.2-weld-2.2.xml
@@ -15,5 +15,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-8.2-weld-3.0.xml
+++ b/wildfly/patch-config-wildfly-8.2-weld-3.0.xml
@@ -16,5 +16,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-9-weld-2.2.xml
+++ b/wildfly/patch-config-wildfly-9-weld-2.2.xml
@@ -15,5 +15,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-9-weld-2.3.xml
+++ b/wildfly/patch-config-wildfly-9-weld-2.3.xml
@@ -15,5 +15,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>

--- a/wildfly/patch-config-wildfly-9-weld-3.0.xml
+++ b/wildfly/patch-config-wildfly-9-weld-3.0.xml
@@ -16,5 +16,4 @@
             </modules>
         </specified-content>
     </element>
-    <specified-content/>
 </patch-config>


### PR DESCRIPTION
This should do the trick. Double check appreciated.
Compared to our patch for 10.1, this one has change in `org.jboss.as.weld.common` module as well.

I took clean WildFly 11, applied patch and run integration/tck tests on it - everything passed.